### PR TITLE
fix: harmony cannot patch non-delcared methods

### DIFF
--- a/1.5/Source/VAspirE/Harmony/SatisfactionPatches.cs
+++ b/1.5/Source/VAspirE/Harmony/SatisfactionPatches.cs
@@ -27,8 +27,9 @@ public static class SatisfactionPatches
         harm.Patch(AccessTools.Method(typeof(Pawn_EquipmentTracker), nameof(Pawn_EquipmentTracker.AddEquipment)),
             postfix: new(typeof(SatisfactionPatches), nameof(CheckGeneral)));
         foreach (var type in typeof(Precept_Role).AllSubclassesNonAbstract())
-            harm.Patch(AccessTools.Method(type, nameof(Precept_Role.Assign)),
-                postfix: new(typeof(SatisfactionPatches), nameof(CheckArgP)));
+            if (type.GetMethods().FirstOrDefault(x => x.Name.Equals(nameof(Precept_Role.Assign)))?.IsDeclaredMember() == true)
+                harm.Patch(AccessTools.Method(type, nameof(Precept_Role.Assign)),
+                    postfix: new(typeof(SatisfactionPatches), nameof(CheckArgP)));
          harm.Patch(AccessTools.Method(typeof(RitualOutcomeEffectWorker_ConnectToTree), nameof(RitualOutcomeEffectWorker_ConnectToTree.Apply)),
             postfix: new(typeof(SatisfactionPatches), nameof(OnTreeLinkGauranlen)));
         harm.Patch(AccessTools.Method(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.BirthdayBiological)),


### PR DESCRIPTION
Fixes an issue with Hospitality where they seem to have an abstract type of `Precept_Role` that implements the method `Assign` with the abstract modifier. Which won't allow for or do implement a body, and Harmony can only patch methods/constructors with bodies. I just made the for-loop check if that method has is a declared member.