### PR TITLE
Move create legendary fulfillment detection to a later time

### DIFF
--- a/1.6/Source/VAspirE/Harmony/SatisfactionPatches.cs
+++ b/1.6/Source/VAspirE/Harmony/SatisfactionPatches.cs
@@ -36,8 +36,8 @@ public static class SatisfactionPatches
             postfix: new(typeof(SatisfactionPatches), nameof(CheckGeneral)));
         harm.Patch(AccessTools.Method(typeof(InspirationHandler), nameof(InspirationHandler.TryStartInspiration)),
             postfix: new(typeof(SatisfactionPatches), nameof(OnInspiration)));
-        harm.Patch(AccessTools.Method(typeof(QualityUtility), nameof(QualityUtility.GenerateQualityCreatedByPawn), new[] { typeof(Pawn), typeof(SkillDef), typeof(bool) }),
-            postfix: new(typeof(SatisfactionPatches), nameof(CheckQuality)));
+        harm.Patch(AccessTools.Method(typeof(QualityUtility), nameof(QualityUtility.SendCraftNotification), [typeof(Thing), typeof(Pawn)]),
+            prefix: new(typeof(SatisfactionPatches), nameof(CheckQuality)));
         harm.Patch(AccessTools.Method(typeof(Pawn_ApparelTracker), nameof(Pawn_ApparelTracker.Wear)),
             postfix: new(typeof(SatisfactionPatches), nameof(CheckGeneral)));
         harm.Patch(AccessTools.Method(typeof(RecordsUtility), nameof(RecordsUtility.Notify_PawnKilled)),
@@ -91,10 +91,10 @@ public static class SatisfactionPatches
             ___pawn?.needs?.Fulfillment()?.Complete(AspirationDefOf.VAspirE_GetInspiration);
     }
 
-    public static void CheckQuality(Pawn pawn, QualityCategory __result)
+    public static void CheckQuality(Thing thing, Pawn worker)
     {
-        if (__result == QualityCategory.Legendary)
-            pawn?.needs?.Fulfillment()?.Complete(AspirationDefOf.VAspirE_CreateLegendary);
+        if (thing.TryGetComp<CompQuality>()?.Quality == QualityCategory.Legendary)
+            worker?.needs?.Fulfillment()?.Complete(AspirationDefOf.VAspirE_CreateLegendary);
     }
 
     public static void OnPawnKilled(Pawn killed, Pawn killer)


### PR DESCRIPTION
Currently, the detection of fulfillment of the create legendary aspiration is in a postfix patch to `GenerateQualityCreatedByPawn`, but some mods also have quality modifying logic in their own postfix patches to `GenerateQualityCreatedByPawn`, like “Vanilla Ideology Expanded - Memes and Structures”. So depending on the patching order, it is possible that due to the effect of mods, a pawn will create a legendary work, but still has its aspiration unfulfilled.

This PR proposes to move the detection to a prefix patch to `SendCraftNotification` so that it works better with other mods.